### PR TITLE
Correctly Specify StreamManagerClient Logger Type

### DIFF
--- a/aws-greengrass-core-sdk/stream-manager/client.js
+++ b/aws-greengrass-core-sdk/stream-manager/client.js
@@ -58,6 +58,7 @@ class StreamManagerClient {
      * @typedef Logger
      * @type {Object}
      * @property {function(...*)} error
+     * @property {function(...*)} warn
      * @property {function(...*)} info
      * @property {function(...*)} debug
      */


### PR DESCRIPTION
StreamManagerClient expects an optional Logger within its constructor.
The Logger type definition does not include a property `warn`, which is
expected by the StreamManagerClient.

This commit adds a property `warn` to the JSDoc typedef for
StreamManagerClient's Logger to reduce the likelihood of users supplying
an invalid Logger.

Resolves #19
